### PR TITLE
Set default question options when there are none in the DB during restore

### DIFF
--- a/edit_mtf_form.php
+++ b/edit_mtf_form.php
@@ -224,13 +224,13 @@ class qtype_mtf_edit_form extends question_edit_form {
         if (isset($this->question->options->rows) && count($this->question->options->rows) > 0) {
             $this->numberofrows = count($this->question->options->rows);
         } else {
-            $this->numberofrows = 4;
+            $this->numberofrows = QTYPE_MTF_NUMBER_OF_OPTIONS;
         }
 
         if (isset($this->question->options->columns) && count($this->question->options->columns) > 0) {
             $this->numberofcolumns = count($this->question->options->columns);
         } else {
-            $this->numberofcolumns = 2;
+            $this->numberofcolumns = QTYPE_MTF_NUMBER_OF_RESPONSES;
         }
 
         $this->editoroptions['changeformat'] = 1;


### PR DESCRIPTION
We have a quiz backup containing mtf questions in a random question using the plugin in version 2025031900.
During the restore on a 5.2dev Moodle with your latest version from master, I get an error by using a property on false.

```
$question->options->rows = $DB->get_records('qtype_mtf_rows',
                array('questionid' => $question->id),
                'number ASC', '*', 0, $question->options->numberofrows);
```

is the code in question where `$question->options` is false. This is because the query `$DB->get_record('qtype_mtf_options',  array('questionid' => $question->id));` returns no results.

Besides that, the question options that are possibly fetched in `parent::get_question_options($question);` two lines above would be overwritten there.
I changed the code by

1. keeping the original question->options.
2. trying to fetch specific options for this single question
3. if there are no specific options, use the defaults.
4. Merge the specific mtf options for that question with any other options.

I also made two little corrections, using a define and dropping the unused index variable in a loop.